### PR TITLE
Load js vars in checkout in Magento 1.8.1

### DIFF
--- a/src/app/design/frontend/base/default/layout/svea_webpay.xml
+++ b/src/app/design/frontend/base/default/layout/svea_webpay.xml
@@ -21,4 +21,10 @@
             </block>
         </reference>
     </streamcheckout_index_index>
+
+    <checkout_onepage_index>
+        <reference name="content">
+            <block type="core/template" name="svea_jsvars" template="svea/payment/service/jsvars.phtml" />
+        </reference>
+    </checkout_onepage_index>
 </layout>

--- a/src/app/design/frontend/base/default/template/svea/payment/service/jsvars.phtml
+++ b/src/app/design/frontend/base/default/template/svea/payment/service/jsvars.phtml
@@ -1,0 +1,11 @@
+<?php
+$_country = Mage::getSingleton('checkout/session')
+    ->getQuote()
+    ->getBillingAddress()
+    ->getCountry();
+?>
+<script>
+    var currentCountry = <?php echo Mage::helper('core')->jsonEncode($_country) ?>;
+    var usingQuickCheckout = <?php echo Mage::helper('core')->jsonEncode($this->helper('svea_webpay')->usingQuickCheckout()) ?>;
+    var getAddressUrl = '<?php echo $this->getUrl('svea_webpay/service/getAddresses', array('_secure' => true)) ?>';
+</script>


### PR DESCRIPTION
Magento 1.8.1 doesn't immediately load the SSN template (where the Svea js variables are) in the standard checkout. The payment methods are only fetched once you proceed to the payment section, and then the js vars are not there. This commit fixes this and makes sure the js vars are loaded beforehand.
